### PR TITLE
extend HIT save timeout for video hits which do not always save in 30 se...

### DIFF
--- a/src/clients/child.coffee
+++ b/src/clients/child.coffee
@@ -71,6 +71,7 @@ class ChildClient extends BaseLogging
     options.body = data
     options.endpoint ?= @get 'resultsUrl'
     options.method   ?= 'POST'
+    options.requestTimeout = 180000
 
     @request options, (err, response)->
       return callback err, response if err


### PR DESCRIPTION
...conds

This extends the save timeout to 3 minutes - for video HITs the transaction in django did not prevent instances where the child client would cancel the request before the server responded.  In these cases, the annotations were saved, but the task doesn't get updated as complete.  This should help alleviate that.
