### PR TITLE
Extend save timeout

### DIFF
--- a/src/clients/child.coffee
+++ b/src/clients/child.coffee
@@ -71,6 +71,7 @@ class ChildClient extends BaseLogging
     options.body = data
     options.endpoint ?= @get 'resultsUrl'
     options.method   ?= 'POST'
+    options.requestTimeout = 180000
 
     @request options, (err, response)->
       return callback err, response if err


### PR DESCRIPTION
Extends the save timeout so video HITs don't cause issues.  These HITs take a bit longer to save - (this process should be optimized too) - and the transformresults were being saved, but because the interface was canceling the request, a critical redirect never happened.
